### PR TITLE
#3 update cts to always use latest (snapshot or release) xtdb connector

### DIFF
--- a/etc/xtdb.yaml
+++ b/etc/xtdb.yaml
@@ -21,6 +21,5 @@ tut:
         db-dir: data/servers/xtdb/lucene
 downloads:
   - filename: egeria-connector-xtdb.jar
-    url: "http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=org.odpi.egeria&a=egeria-connector-xtdb&v=RELEASE&c=jar-with-dependencies"
-    #url: "http://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.odpi.egeria&a=egeria-connector-xtdb&v=3.15-SNAPSHOT&c=jar-with-dependencies"
+    url: "http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=org.odpi.egeria&a=egeria-connector-xtdb&v=LATEST&c=jar-with-dependencies"
 


### PR DESCRIPTION
* Updates CTS to always use the 'latest' version (as returned by sonatype nexus) of the xtdb connector
* This is literally the latest, so we need to bear in mind that if a xtdb release pipeline is run, that output would become latest, so there could be a short term regression in version. However it's the closest we can get without regularly updating
