### PR TITLE
Use latest 4.0 snapshot for xtdb

### DIFF
--- a/etc/xtdb.yaml
+++ b/etc/xtdb.yaml
@@ -21,5 +21,7 @@ tut:
         db-dir: data/servers/xtdb/lucene
 downloads:
   - filename: egeria-connector-xtdb.jar
-    url: "http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=org.odpi.egeria&a=egeria-connector-xtdb&v=LATEST&c=jar-with-dependencies"
+    #url: "http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=org.odpi.egeria&a=egeria-connector-xtdb&v=LATEST&c=jar-with-dependencies"
+    #Awaiting correct redirect syntax, so interim direct url https://community.sonatype.com/t/retrieving-the-latest-snapshot/10311
+    url: https://oss.sonatype.org/service/local/repositories/snapshots/content/org/odpi/egeria/egeria-connector-xtdb/4.0-SNAPSHOT/egeria-connector-xtdb-4.0-20230316.072650-4-jar-with-dependencies.jar
 


### PR DESCRIPTION
- Updates xtdb connector to v4
- Uses a hardcoded specific snapshot as an interim measure until https://community.sonatype.com/t/retrieving-the-latest-snapshot/10311 is resolved