### PR TITLE
Do #7 wait for init/config to complete & capture logs

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -99,7 +99,13 @@ jobs:
           sleep 1
           done
           kubectl wait pods --selector=app.kubernetes.io/component=platform --for condition=Ready --timeout=5m
-      # We could wait for the init job to complete, but the risk is it gets purged - so for now, skip this check
+      - name: Wait for init/config to complete
+        run: |
+          until kubectl get pod -l app.kubernetes.io/component=init -o go-template='{{.items | len}}' | grep -qxF 1; do
+          echo "Waiting for pod"
+          sleep 1
+          done
+          kubectl wait pods --selector=app.kubernetes.io/component=init --for condition=complete --timeout=5m
       - name: Wait for CTS results to be available (this takes a long time - HOURS)
         # This waits for the report pod to go ready - this means results are ready
         run: |
@@ -108,7 +114,7 @@ jobs:
           sleep 1
           done
           # -- note on timeouts --
-          # Above we've used 25 mins. Allow 5 mins for logging retrieval, + some for attachments so allow 5:20 hours here to be safe
+          # Above we've used 30 mins. Allow 5 mins for logging retrieval, + some for attachments so allow 5:20 hours here to be safe
           # But note that kubectl exec timeouts are tricky - combo of finding running pod, connecting to pod, and running command, so are omitted below
           # TODO: Could be calculated based on start time of job to maximise available job run time
           # -- end --
@@ -121,6 +127,10 @@ jobs:
       - name: Gather CTS report
         run: |
           kubectl exec $(kubectl get pod -l app.kubernetes.io/component=report --no-headers -o custom-columns=":metadata.name") -- sh -c 'cat /export/pipe' | tar -xvf -
+      - name: capture k8s logs from init job
+        if: always()
+        run : |
+          kubectl logs -l app.kubernetes.io/component=init --since=6h > init.log
       - name: capture k8s logs from platform
         if: always()
         run : |
@@ -133,6 +143,7 @@ jobs:
           path: |
             export/cts.tar.gz
             platform.log
+            init.log
       - name: Analyze Results
         run: |
           python3 scripts/cts-analyze.py > analysis.txt 2>&1


### PR DESCRIPTION
Reliability improvements for executing CTS
 - wait for platform configuration to complete
 - capture log from platform configuration
 - post log as part of attachment on job completion
 
 This will enable the log of REST commands sent to the TUT/SUT servers to be reviewed if the tests fail.
 
 For example, #7 reports an issue where the CTS fails due to a download failure of the connector. Whilst the summary will be no different after the fix (a future option?), the attached files would make it possible to determine what had happened without having to guess or rerun
 
 (ci/cd job - so will merge & then review results after to confirm fix is good)