### PR TITLE
#7 correct wait: pods->job (for config task)

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -105,7 +105,7 @@ jobs:
           echo "Waiting for pod"
           sleep 1
           done
-          kubectl wait pods --selector=app.kubernetes.io/component=init --for condition=complete --timeout=5m
+          kubectl wait jobs --selector=app.kubernetes.io/component=init --for condition=complete --timeout=5m
       - name: Wait for CTS results to be available (this takes a long time - HOURS)
         # This waits for the report pod to go ready - this means results are ready
         run: |


### PR DESCRIPTION
Corrects command to wait for completion of egeria cts configuration to (example):

This fails:
```
kubectl wait pods --selector=app.kubernetes.io/component=init --for condition=Completed --timeout=10s
error: timed out waiting for the condition on pods/cts-init-p49hn
```

But this works:
```
kubectl wait jobs --selector=app.kubernetes.io/component=init --for condition=complete --timeout=10s
job.batch/cts-init condition met
```