### PR TITLE
use maven repo url for xtdb connector

### DIFF
--- a/etc/xtdb.yaml
+++ b/etc/xtdb.yaml
@@ -21,7 +21,7 @@ tut:
         db-dir: data/servers/xtdb/lucene
 downloads:
   - filename: egeria-connector-xtdb.jar
-    url: "http://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=org.odpi.egeria&a=egeria-connector-xtdb&v=LATEST&c=jar-with-dependencies"
+    url: "https://repo1.maven.org/maven2/org/odpi/egeria/egeria-connector-xtdb/4.0/egeria-connector-xtdb-4.0-jar-with-dependencies.jar"
     #Awaiting correct redirect syntax, so interim direct url https://community.sonatype.com/t/retrieving-the-latest-snapshot/10311
     #url: https://oss.sonatype.org/service/local/repositories/snapshots/content/org/odpi/egeria/egeria-connector-xtdb/4.0-SNAPSHOT/egeria-connector-xtdb-4.0-20230316.072650-4-jar-with-dependencies.jar
 


### PR DESCRIPTION
Using default maven repo url for connector download. 
Version is part of the URL, can be externalized later.